### PR TITLE
feat: run cd when to be released

### DIFF
--- a/.github/workflows/deploy-ununifi-client-npm-publish.yml
+++ b/.github/workflows/deploy-ununifi-client-npm-publish.yml
@@ -1,6 +1,10 @@
 name: CD ununifi-client npm publish
 
-on: [workflow_dispatch]
+on: 
+  release:
+    types:
+      - created
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/deploy-ununifi-client-npm-publish.yml
+++ b/.github/workflows/deploy-ununifi-client-npm-publish.yml
@@ -1,6 +1,6 @@
 name: CD ununifi-client npm publish
 
-on: 
+on:
   release:
     types:
       - created
@@ -27,7 +27,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - run: npm i -g npm
       - run: npm ci
       - run: npm run build --if-present
       - run: npm publish --access=public


### PR DESCRIPTION
PR to configure cd timing for release.

I have a question.

https://github.com/cosmos-client/ununifi-ts/blob/02a0f5f7ecf5c68de02d06ab226a77229b1a0d18/.github/workflows/deploy-ununifi-client-npm-publish.yml#L30

Is this line necessary?
If so, why?